### PR TITLE
step18

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,7 +2,8 @@ class CategoriesController < ApplicationController
   before_action :set_category, only: [:show, :edit, :update, :destroy]
 
   def index
-    @categories = Category.all
+    @categories = Category.all.page(params[:page])
+    @categories = @categories.where('title LIKE ?', "%#{params[:search]}%") if params[:search].present?
   end
 
   def show

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,8 +2,7 @@ class CategoriesController < ApplicationController
   before_action :set_category, only: [:show, :edit, :update, :destroy]
 
   def index
-    @categories = Category.all.page(params[:page])
-    @categories = @categories.where('title LIKE ?', "%#{params[:search]}%") if params[:search].present?
+    @categories = Category.categories_search(params[:search]).page(params[:page])
   end
 
   def show

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -4,6 +4,8 @@ class Category < ApplicationRecord
 
   validates :title, presence: true
 
+  scope :categories_search, -> (search) { search.present? ? where('title LIKE ?', "%#{search}%") : all }
+
   def self.ransackable_attributes(auth_object = nil)
     super + ['title']
   end

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -4,4 +4,11 @@
   <% @categories.each do |category| %>
     <li><%= link_to(category.title, category_path(category)) %></li>
   <% end %>    
-</ul>    
+</ul> 
+<%= paginate @categories %>   
+<p>カテゴリー検索</p>
+<%= form_with url: categories_path, method: :get, local: true do |form| %>
+  <%= form.text_field :search %>
+  <%= form.submit '検索' %>
+<% end %>
+

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -6,6 +6,18 @@ RSpec.describe CategoriesController, type: :request do
       get categories_path
       expect(response).to have_http_status 200
     end
+
+    let!(:category1) { create(:category, title: 'Example Category') }
+
+    it 'データが存在する場合、一致するレコードを表示すること' do
+      get categories_path, params: { search: 'Example' }
+      expect(response.body).to include(category1.title)
+    end
+
+    it '一致するデータが存在しない場合、レコードを表示しないこと' do
+      get categories_path, params: { search: 'Nonexistent' }
+      expect(response.body).not_to include(category1.title)
+    end
   end
 
   describe 'GET #show' do


### PR DESCRIPTION
ransackを使用せずにカテゴリの一覧画面でカテゴリ名を検索できるようにしましょう
ステップ17で実施したタスク一覧のページネーションと同様に､カテゴリ一覧にもページネーションを適用しましょう
